### PR TITLE
Fix the res variable not found on signup

### DIFF
--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -34,11 +34,14 @@ module SessionsHelper
     res = @user.find_by_remember_token(cookies[:remember_token], cookies[:email]) if cookies[:remember_token] && cookies[:email]
     res != nil
   end
-  
+
  #return the current_user object by looking at the  remembertoken, email from cookie jar or
  #redirect to the sign page.
  def current_user
-    if user_in_cookie?
+   @user = User.new
+   res = @user.find_by_remember_token(cookies[:remember_token], cookies[:email]) if cookies[:remember_token] && cookies[:email]
+
+    if res != nil
       @current_user ||= res
      else
       redirect_to signin_path


### PR DESCRIPTION
`res` was not found in current_user problem is fixed. We just have to add a call to 

```
user.find_remember..

```

inside `current_user` method.
