### PR TITLE
Added start/stop/restart and delete ops.

### DIFF
--- a/app/controllers/concerns/pilotable.rb
+++ b/app/controllers/concerns/pilotable.rb
@@ -25,13 +25,30 @@ module Pilotable
     attr_writer :create, :destroy
   end
 
-  def create
-    puts "--- catrequests hack --"
+  #this action gets called prior to a start, stop, restart, delete operation
+  # a confirmation is got from the user to perform the same.
+  def precreate
+    @id = params[:id]
+    @name = params[:name]
+    @command = params[:command]
+    @type = params[:type]
+    respond_to do |format|
+      format.js {
+        respond_with(@id, @name, @command, @type, :layout => !request.xhr? )
+      }
+    end
   end
 
-  #destroy
+  #this action performs a start, stop, restart operation
+  def create
+    logger.debug "> Pilotable: create"
+    Requests.new.catreqs(params)
+  end
+
+  #this action perfroms a delete operation.
   def destroy
-    puts "--- catrequests hack --"
+    logger.debug "> Pilotable: destroy"
+    Requests.new.reqs(params)
   end
 
 end

--- a/app/models/requests.rb
+++ b/app/models/requests.rb
@@ -13,7 +13,7 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 ##
-class Marketplaces < BaseFascade
+class Requests < BaseFascade
   include MarketplaceHelper
 
   attr_reader :req_submitted
@@ -22,16 +22,18 @@ class Marketplaces < BaseFascade
     @req_submitted = []
   end
 
-  #This just creates a Requests
-  def list(api_params, &block)
+  #This  creates a /requests
+  # used during CREATION and DELETE
+  def reqs(api_params, &block)
     raw = api_request(api_params, REQUESTS, CREATE)
     @req_submitted =  raw[:body]
     yield self  if block_given?
     return self
   end
 
-  # This creates a AppRequests
-  def show(api_params, &block)
+  # This creates a /catrequests
+  # called during START, STOP, RESTART
+  def catreqs(api_params, &block)
      raw = api_request(api_params, CATREQUESTS, CREATE)
      @req_submitted =  raw[:body]
      yield self  if block_given?

--- a/app/views/catalogs/_pilotable.html.erb
+++ b/app/views/catalogs/_pilotable.html.erb
@@ -1,17 +1,17 @@
 <!-- CATALOG START MODAL -->
-<div class="modal fade app_exist" id="app_start" tabindex="-1" role="basic" aria-hidden="true">
+<div class="modal fade app_exist" id="<%=catname.downcase%>_start" tabindex="-1" role="basic" aria-hidden="true">
 	<div class="modal-dialog">
-		<%= form_tag controls_path, multipart: true, :novalidate => 'novalidate',  :method => 'post', :remote => true  do %>
+		<%= form_tag catalogs_path, multipart: true, :novalidate => 'novalidate',  :method => 'post', :remote => true  do %>
 		<div class="modal-content c_modal-content">
 			<div class="modal-header">
 				<button type="button" class="close" data-dismiss="modal" aria-hidden="true"></button>
-				<h4 class="modal-title">Start App</h4>
+				<h4 class="modal-title">Start <%= catname %></h4>
 			</div>
 			<div class="modal-body text-center">
 				<span id="start_app_id"></span>
 				<span id="start_app_name"></span>
-				<%= hidden_field_tag 'command', nil, placeholder: "", :class =>"form-control", :value => "start"  %>
-				Are you sure you want to start the app ?
+				<%= hidden_field_tag 'command', nil, placeholder: "", :class =>"form-control", :value => Assemblies::START  %>
+				Are you sure you want to start the <%= catname.downcase %> ?
 			</div>
 			<div class="modal-footer c_modal-footer">
 				<button type="button" class="btn default" data-dismiss="modal">
@@ -28,19 +28,19 @@
 <!-- /.modal -->
 
 <!-- CATALOG STOP MODAL -->
-<div class="modal fade app_exist" id="app_stop" tabindex="-1" role="basic" aria-hidden="true">
+<div class="modal fade app_exist" id="<%=catname.downcase%>_stop" tabindex="-1" role="basic" aria-hidden="true">
 	<div class="modal-dialog">
-		<%= form_tag controls_path, multipart: true, :novalidate => 'novalidate',  :method => 'post', :remote => true  do %>
+		<%= form_tag catalogs_path, multipart: true, :novalidate => 'novalidate',  :method => 'post', :remote => true  do %>
 		<div class="modal-content c_modal-content">
 			<div class="modal-header">
 				<button type="button" class="close" data-dismiss="modal" aria-hidden="true"></button>
-				<h4 class="modal-title">Stop App</h4>
+				<h4 class="modal-title">Stop <%= catname %></h4>
 			</div>
 			<div class="modal-body text-center">
 				<span id="stop_app_id"></span>
 				<span id="stop_app_name"></span>
-				<%= hidden_field_tag 'command', nil, placeholder: "", :class =>"form-control", :value => "stop"  %>
-				Are you sure you want to stop the app ?
+				<%= hidden_field_tag 'command', nil, placeholder: "", :class =>"form-control", :value => Assemblies::STOP  %>
+				Are you sure you want to stop the <%= catname.downcase %> ?
 			</div>
 			<div class="modal-footer c_modal-footer">
 				<button type="button" class="btn default" data-dismiss="modal">
@@ -57,19 +57,19 @@
 <!-- /.modal -->
 
 <!-- CATALOG RESTART MODAL -->
-<div class="modal fade app_exist" id="app_restart" tabindex="-1" role="basic" aria-hidden="true">
+<div class="modal fade app_exist" id="<%= catname.downcase %>_restart" tabindex="-1" role="basic" aria-hidden="true">
 	<div class="modal-dialog">
-		<%= form_tag controls_path, multipart: true, :novalidate => 'novalidate',  :method => 'post', :remote => true  do %>
+		<%= form_tag catalogs_path, multipart: true, :novalidate => 'novalidate',  :method => 'post', :remote => true  do %>
 		<div class="modal-content c_modal-content">
 			<div class="modal-header">
 				<button type="button" class="close" data-dismiss="modal" aria-hidden="true"></button>
-				<h4 class="modal-title">Restart App</h4>
+				<h4 class="modal-title">Restart <%= catname %></h4>
 			</div>
 			<div class="modal-body text-center">
 				<span id="restart_app_id"></span>
 				<span id="restart_app_name"></span>
-				<%= hidden_field_tag 'command', nil, placeholder: "", :class =>"form-control", :value => "restart"  %>
-				Are you sure you want to restart the app ?
+				<%= hidden_field_tag 'command', nil, placeholder: "", :class =>"form-control", :value => Assemblies::RESTART  %>
+				Are you sure you want to restart the <%= catname.downcase %> ?
 			</div>
 			<div class="modal-footer c_modal-footer">
 				<button type="button" class="btn default" data-dismiss="modal">
@@ -85,21 +85,21 @@
 </div>
 <!-- /.modal -->
 <!-- CATALOG DELETE MODAL -->
-<div class="modal fade app_exist" id="app_delete" tabindex="-1" role="basic" aria-hidden="true">
+<div class="modal fade app_exist" id="<%= catname.downcase %>_delete" tabindex="-1" role="basic" aria-hidden="true">
 	<div class="modal-dialog">
-		<%= form_tag controls_path, multipart: true, :novalidate => 'novalidate',  :method => 'post', :remote => true  do %>
+		<%= form_tag catalogs_path, multipart: true, :novalidate => 'novalidate',  :method => 'post', :remote => true  do %>
 		<div class="modal-content c_modal-content">
 			<div class="modal-header">
 				<button type="button" class="close" data-dismiss="modal" aria-hidden="true"></button>
-				<h4 class="modal-title">Delete App</h4>
+				<h4 class="modal-title">Delete <%= catname %></h4>
 			</div>
 
 			<div class="modal-body text-center">
 				<span id="delete_app_id"></span>
 				<span id="delete_app_name"></span>
-				<%= hidden_field_tag 'command', nil, placeholder: "", :class =>"form-control", :value => "delete"  %>
+				<%= hidden_field_tag 'command', nil, placeholder: "", :class =>"form-control", :value => Assemblies::DELETE  %>
 
-				Are you sure you want to delete the app ?
+				Are you sure you want to delete the <%= catname.downcase %> ?
 			</div>
 			<div class="modal-footer c_modal-footer">
 				<button type="button" class="btn default" data-dismiss="modal">
@@ -121,31 +121,10 @@
 		<div class="modal-content c_modal-content">
 			<div class="modal-header">
 				<button type="button" class="close" data-dismiss="modal" aria-hidden="true"></button>
-				<h4 class="modal-title"><div id="command_msg"></div> App</h4>
+				<h4 class="modal-title"><div id="command_msg"></div> <%= catname %></h4>
 			</div>
 			<div class="modal-body text-center">
-				<div id="app_res_msg"></div>
-			</div>
-			<div class="modal-footer c_modal-footer">
-				<%= link_to  "Ok", cockpits_path, :class => "btn btn-success", :target => "_self" %>
-			</div>
-		</div>
-		<!-- /.modal-content -->
-	</div>
-	<!-- /.modal-dialog -->
-</div>
-
-<div class="modal fade" id="app_postfinish_popup_error" tabindex="-1" role="basic" aria-hidden="true">
-	<div class="modal-dialog">
-		<div class="modal-content c_modal-content">
-			<div class="modal-header">
-				<button type="button" class="close" data-dismiss="modal" aria-hidden="true"></button>
-				<h4 class="modal-title"><div id="command_msg"></div> App</h4>
-			</div>
-			<div class="modal-body text-center">
-				Whew! Failed to App Request published.
-				</br>
-				<div id="app_err_msg"></div>
+				<div id="success"></div>
 			</div>
 			<div class="modal-footer c_modal-footer">
 				<%= link_to  "Ok", cockpits_path, :class => "btn btn-success", :target => "_self" %>

--- a/app/views/cockpits/_flyasm.html.erb
+++ b/app/views/cockpits/_flyasm.html.erb
@@ -141,3 +141,4 @@
 <% end %>
 </div>
 </div><!-- services ends here -->
+<%= render :partial => "catalogs/pilotable", :locals => {:catname => catname} %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -36,7 +36,7 @@
 							<%= link_to catalogs_path(:cattype => Assemblies::DEW ), :data => { :remote => true},:target => "_self" do %>
 							<i class="icon-bar-chart pull-left"></i>
 							<span class="title pull-left">Dews</span>
-							<span class="hidden-xs <%= "selected" if controller_name == "cockpits"%>"></span>
+							<span class="hidden-xs <%= "selected" if params["cattype"] == Assemblies::DEW %>"></span>
 							<% end %>
 						</li>
 


### PR DESCRIPTION
@rajthilakmca @morpheyesh @thomasalrin 

`Pilotable` is a `Rails Concern` that can be added to any controller to enrich its controls. The controls we are talking about are the lifecycle operations like (start, stop, restart and delete).

I added the `_pilotable` template which has `start, stop, restart and delete` partial in the view `flyasm`.

The `flyasm` template gets added one per cattype [APP, SERVICE, ADDON ..]
### 3 methods in  `Pilotable`

As we have 2 categories of requests, we have two methods in one model named `Requests`.
- precreate
  Before any start, stop, restart or delete is called a popup needs to shown to confirm the same. 
- create
  This calls the `Requests` model and invokes `catreqs`
- destroy
  This call the `Requests` models and invokes `reqs` method.

@morpheyesh Test it out please.
