### PR TITLE
The request from launch of marketplace is just a plain req (no ajax)

### DIFF
--- a/app/assets/stylesheets/market_place.css
+++ b/app/assets/stylesheets/market_place.css
@@ -163,4 +163,3 @@ input[type=checkbox] {
 .check_ci input[type=checkbox]:checked + label {
 	left: 43px;
 }
-

--- a/app/controllers/marketplaces_controller.rb
+++ b/app/controllers/marketplaces_controller.rb
@@ -159,7 +159,7 @@ class MarketplacesController < ApplicationController
     puts "+++++++++++++++++++++++++++++++++"
     puts params
     if params[:sshoption] == "CREATE"
-      
+
     end
   end
 

--- a/app/views/billings/index.html.erb
+++ b/app/views/billings/index.html.erb
@@ -1,0 +1,6 @@
+
+<% content_for :content_settings do %>
+<%= provide(:title, 'Billings') %>
+<%= render :partial => "billings/mybilling", :locals => {:ssh_keys => @ssh_keys} %>
+<% end %>
+<%= render :template => "users/show" %>

--- a/app/views/marketplaces/_catalog.html.erb
+++ b/app/views/marketplaces/_catalog.html.erb
@@ -71,7 +71,7 @@
 						<div class="app_inner brad-3 jcorgFilterTextParent">
 							<a data-toggle="modal" href="#app-1">
 							<div class="stpack ">
-								<%= link_to marketplace_path(:id => mkp.name), :target => "_self", :remote => true, :class => "link_img hint  hint--bottom", 'data-hint' => "Launch ! #{mkp.name.split("-").last}" do %>
+								<%= link_to marketplace_path(:id => mkp.name), 'data-remote' => "true", :class => "link_img hint  hint--bottom", 'data-hint' => "Launch ! #{mkp.name.split("-").last}" do %>
 								<%= image_tag mkp.catalog[:logo], :alt => mkp.name %>
 								<% end %>
 							</div> </a>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,7 +48,4 @@ Nilavu::Application.routes.draw do
   match '/varai', to: 'cockpit#varai', via: [:get]
 
 
-# named route for ssh_keys
-  match '/sshkey/import', to: 'ssh_keys#sshkey_import', via: [:get]
-
 end


### PR DESCRIPTION
If you click on any item in marketplace, the launch request doesn't get invoked in an ajax way from marketplace. If the credit is zero, it redirects to billing page. I tried to use `data-remote` but invain. Hence i changed it back to a regular request approach.
### Template naming and adherence to support both request and ajax approach.

We need to avoid code redundancy.
- Hence create a partial prefixed by name `my<cockpit> for index`
- Create a template like index.js.erb which renders a partial  `_mycockpit`
- If you have to support a regular request then the template `index.html.erb` shall also render the partial along with the left nav. 

eg:

``` ruby
#index.js.erb
$("#content").html("<%= escape_javascript(render :partial => "billings/mybilling", :locals => {:ssh_keys => @ssh_keys}) %>");

```

``` ruby
#index.html.erb
<% content_for :content_settings do %>
<%= provide(:title, 'Billings') %>
<%= render :partial => "billings/mybilling", :locals => {:ssh_keys => @ssh_keys} %>
<% end %>
<%= render :template => "users/show" %>
```
