### PR TITLE
singleton, marketplace list doesn't get loaded always

### DIFF
--- a/app/models/marketplaces.rb
+++ b/app/models/marketplaces.rb
@@ -46,11 +46,12 @@ class Marketplaces < BaseFascade
   #                                   Platform
   #                                   Analytics
   def list(api_params, &block)
-    raw = api_request(api_params, MARKETPLACES, LIST)
-    @mkp_collection =  raw[:body] unless raw == nil
+    unless !@mkp_grouped.empty? #a patch to load mkp_grouped from cache, as this object is singleton. Maybe memcache can help us.
+      raw = api_request(api_params, MARKETPLACES, LIST)
+      @mkp_collection =  raw[:body] unless raw == nil
 
-    @mkp_grouped = Hash[@mkp_collection.group_by{ |tmp| tmp.catalog[:category] }.map{|k,v| [k,v.map{|h|h}]}]
-
+      @mkp_grouped = Hash[@mkp_collection.group_by{ |tmp| tmp.catalog[:category] }.map{|k,v| [k,v.map{|h|h}]}]
+    end
     yield self  if block_given?
     return self
   end


### PR DESCRIPTION
### Marketplace domain is a singleton

A singleton essentially means that there will be just one copy loaded in memory. The marketplace list and show methods are loaded in the `mkp_grouped` object upon first fetch.

If it doesn't exists then  an api_request is performed to gateway.

This is a good candidate for Memcache stuff in the future.
