### PR TITLE
ok, the cockpit is ready to be piloted again. check it out.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem 'riak-client', '~> 2.1.0'
 #general
 gem "github_api", "~>0.12.3"
 gem "randexp", "~> 0.1.7"
-gem "megam_api", "~> 0.47"
+gem "megam_api", "~> 0.49"
 gem 'google-analytics-rails', '~> 0.0.6'
 gem 'megam_gogs', "~> 0.7.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -226,7 +226,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    megam_api (0.47)
+    megam_api (0.49)
       excon (~> 0.45.3)
       highline (~> 1.7)
       mixlib-config (~> 2.1)
@@ -417,7 +417,7 @@ DEPENDENCIES
   jquery-turbolinks (~> 2.1.0)
   json (~> 1.8.2)
   less-rails (~> 2.7.0)
-  megam_api (~> 0.47)
+  megam_api (~> 0.49)
   megam_gogs (~> 0.7.0)
   meta_request
   nokogiri (~> 1.6.6.2)

--- a/app/models/assembly.rb
+++ b/app/models/assembly.rb
@@ -19,73 +19,93 @@ require 'json'
 class Assembly < BaseFascade
 
   attr_reader :assembly_collection
-  
-   STATUS    =  'LAUNCHING'.freeze
+  attr_reader :by_cattypes
+  attr_reader :tosca_type
+  attr_reader :components
+
+  DEFAULT_TOSCA_PREFIX = 'tosca'.freeze
+  #this is a mutable string, if nothing exists then we use ubuntu
+  DEFAULT_TOSCA_SUFFIX = 'ubuntu'.freeze
+
 
   def initialize()
     @assembly_collection= nil
-    @DEFAULTTOSCATYPE    =  'ubuntu'  
+    @by_cattypes = {}
     @inputs = []
     @requirements = []
+    @components = []
   end
 
   def show(api_params, &block)
     raw = api_request(api_params, ASSEMBLY, SHOW)
-    @assembly_collection = dig_components(raw[:body])
-    yield @assembly_collection  if block_given?
-    return @assembly_collection
+    @assembly_collection =  dig_components(raw[:body])
+    yield self  if block_given?
+    return self
   end
 
  def build(params)
-  mkp = JSON.parse(params["mkp"])  
-  
-  set_inputs(params)
-  set_requirements(params) 
-  
-  @DEFAULTTOSCATYPE = "#{mkp["predef"]}" unless mkp["cattype"] != Assemblies::DEW
-  
-  components = []  
-  components = Components.new.build(params) unless mkp["cattype"] == Assemblies::DEW
-  
-  hash = [{         
-          "name"=>"#{params[:name]}",
-          "tosca_type"=>"tosca.#{mkp["cattype"].downcase}.#{@DEFAULTTOSCATYPE}",
-          "components"=> components,
-          "requirements"=> @requirements,
-          "policies"=>build_policies(params),
-          "inputs"=> @inputs,
-          "outputs"=>[],
-          "operations"=>[],
-          "status"=>STATUS,
+  mkp = JSON.parse(params["mkp"])
+
+  bld_toscatype(mkp)
+  bld_components(params) unless mkp["cattype"] == Assemblies::DEW
+  bld_requirements(params)
+  bld_inputs(params)
+
+  [{
+      "name"=>"#{params[:name]}",
+      "tosca_type"=> "#{tosca_type}",
+      "components"=> components,
+      "requirements"=> @requirements,
+      "policies"=>bld_policies(params),
+      "inputs"=> @inputs,
+      "outputs"=>[],
+      "operations"=>[],
+      "status"=> Assemblies::LAUNCHING,
         }]
-  hash
+
  end
- 
- #In future lot of inputs add this method
- def set_inputs(params)
-   @inputs << {"key" => "sshkey", "value" => params[:ssh_key_name]} if params[:ssh_key_name] 
+
+
+
+ private
+
+ def bld_toscatype(mkp)
+   tosca_suffix = DEFAULT_TOSCA_SUFFIX
+   tosca_suffix = "#{mkp["predef"]}" unless mkp["cattype"] != Assemblies::DEW
+   @tosca_type = DEFAULT_TOSCA_PREFIX +  ".#{mkp["cattype"].downcase}.#{tosca_suffix}"
  end
- 
+
+ ##For a vm, there is no component to start with, hence this is skipped.
+ def bld_components(params)
+   @components = Components.new.build(params)
+ end
+
  #In future lot of requirements add this method
- def set_requirements(params)
+ def bld_requirements(params)
    @requirements << {"key" => "host", "value" => params[:host]} if params.has_key?(:host)
  end
- 
-  def build_policies(options)
-    mkp = JSON.parse(options["mkp"])
+
+
+def bld_policies(params)
+    mkp = JSON.parse(params["mkp"])
     com = []
-    if options[:appname] != nil && options[:servicename] != nil
+    if params[:appname] != nil && params[:servicename] != nil
       value = {
         :name=>"bind policy",
         :ptype=>"colocated",
         :members=>[
-          "#{options[:name]}.#{options[:domain]}/#{options[:appname]}",
-          "#{options[:name]}.#{options[:domain]}/#{options[:servicename]}"
+          "#{params[:name]}.#{params[:domain]}/#{params[:appname]}",
+          "#{params[:name]}.#{params[:domain]}/#{params[:servicename]}"
         ]
       }
     com << value
     end unless mkp["cattype"] == Assemblies::DEW
     com
+  end
+
+  #In future lot of inputs add this method
+  def bld_inputs(params)
+    @inputs << {"key" => "sshkey", "value" => params[:ssh_key_name]} if params[:ssh_key_name]
   end
 
   #wade out the nils in the assemblys_collection.
@@ -99,18 +119,23 @@ class Assembly < BaseFascade
     end unless (one_assembly.nil? || one_assembly.is_a?(Megam::Error))
   end
 
-  private
 
   def dig_components(tmp_assembly_collection)
     tmp_assembly_collection.map do |one_assembly|
-      one_assembly.components.map do |one_component|
+       a0 = one_assembly.components.map do |one_component|
         if !one_component.empty?
-          Components.show(one_component).components
+          one_component = Components.new.show(api_params.merge({"id" => one_component})).components
         else
           nil
         end
       end
+      one_assembly.components.replace(a0)
+      @by_cattypes[Assemblies::CATTYPES.select {|catt|  catt if one_assembly.tosca_type.match(catt.downcase)}] = one_assembly
     end
+    Rails.logger.debug ">-- ASC: START"
+    Rails.logger.debug "#{@by_cattypes.inspect}"
+    Rails.logger.debug "> ASC: END"
+    tmp_assembly_collection
   end
 
 end

--- a/app/models/components.rb
+++ b/app/models/components.rb
@@ -19,6 +19,7 @@ require 'json'
 class Components < BaseFascade
 
   attr_reader :components
+
   def initialize()
     @components= nil
     @name = nil
@@ -30,8 +31,8 @@ class Components < BaseFascade
 
   def show(api_params, &block)
     @components = api_request(api_params, COMPONENTS, SHOW)[:body]
-    yield @components if block_given?
-    return @components
+    yield self if block_given?
+    return self
   end
 
   def prune

--- a/app/views/catalogs/_cattypes.html.erb
+++ b/app/views/catalogs/_cattypes.html.erb
@@ -34,6 +34,6 @@
 		</div>
 	</div>
 	<div class="margin_30 pad_t25">
-		<%= render :partial => "cockpits/flyasm", :locals => {:catname => @catname.downcase.pluralize, :assemblies_grouped => @assemblies_grouped } %>
+		<%= render :partial => "cockpits/flyasm", :locals => {:catname => @catname.downcase.pluralize, :assemblies_grouped => @assemblies_grouped[@catname] } %>
 	</div>
 </div>

--- a/app/views/cockpits/_flyasm.html.erb
+++ b/app/views/cockpits/_flyasm.html.erb
@@ -23,49 +23,46 @@
   </div>
 </div>
 <% end %>
-
-<% @assemblies_grouped.each do |one_assemblies| %>
-<% one_assemblies.assemblies.each do |assembly| %>
-<% unless assembly[0].status == Assemblies::TERMINATED %>
+<% @assemblies_grouped.values.each do |assembly| %>
+<% unless assembly.status == Assemblies::TERMINATED %>
 <div class="col-xs-12 col-sm-6 col-md-4 col-lg-3 col-xl-3 app_cover">
   <div class="app_inner">
     <div class="app">
       <div class="app_head">
-        <span class="app_config" id="config_menu_<%= assembly[0].name %>_app"><i class="c_icon-config"></i></span>
-        <div class="config_menu config_menu_<%= assembly[0].name %>_app">
+        <span class="app_config" id="config_menu_<%= assembly.name %>_app"><i class="c_icon-config"></i></span>
+        <div class="config_menu config_menu_<%= assembly.name %>_app">
           <ul>
             <li>
-              <%= link_to catalogs_path(:id => assembly[0].id, :name => assembly[0].name, :command => Assemblies::START, :type => Assemblies::DEW.downcase.pluralize), :remote => true do %>
+              <%= link_to catalogs_path(:id => assembly.id, :name => assembly.name, :command => Assemblies::START, :type => Assemblies::DEW.downcase.pluralize), :remote => true do %>
               <i class="glyphicon glyphicon-play-circle"></i>Start <=% @catname %>
               <% end %>
             </li>
             <li>
-              <%= link_to catalogs_path(:id => assembly[0].id, :name => assembly[0].name, :command => Assemblies::STOP, :type => Assemblies::DEW.downcase.pluralize), :remote => true do %>
+              <%= link_to catalogs_path(:id => assembly.id, :name => assembly.name, :command => Assemblies::STOP, :type => Assemblies::DEW.downcase.pluralize), :remote => true do %>
               <i class="glyphicon glyphicon-record"></i>Stop <=% @catname %>
               <% end %>
             </li>
             <li>
-              <%= link_to catalogs_path(:id => assembly[0].id, :name => assembly[0].name, :command => Assemblies::RESTART, :type => Assemblies::DEW.downcase.pluralize), :remote => true do %>
+              <%= link_to catalogs_path(:id => assembly.id, :name => assembly.name, :command => Assemblies::RESTART, :type => Assemblies::DEW.downcase.pluralize), :remote => true do %>
               <i class="glyphicon glyphicon-refresh"></i>Restart <=% @catname %>
               <% end %>
             </li>
             <li>
-              <%= link_to catalogs_path(:id => assembly[0].id, :name => assembly[0].name, :command => Assemblies::DELETE, :type => Assemblies::DEW.downcase.pluralize), :remote => true do %>
+              <%= link_to catalogs_path(:id => assembly.id, :name => assembly.name, :command => Assemblies::DELETE, :type => Assemblies::DEW.downcase.pluralize), :remote => true do %>
               <i class="glyphicon glyphicon-trash"></i>Delete <=% @catname %>
               <% end %>
             </li>
           </ul>
         </div>
         <div class="row app_icon">
-          <h5><%= assembly[0].name %></h5>
-        <!--  <% appkey = assembly[0].name + ".megam.io" %>
-          <% appkey = assembly[0].name + "." + assembly[0].components[0][0].inputs[:domain] %>
-          <%= link_to appkey, dewsoverview_path(:appkey => assembly[0].id), :data => {:remote => true} %>
-          <%= link_to appkey, addonsoverview_path(:appkey => assembly[0].id) %>
-          <%= link_to appkey, appoverview_path(:appkey => assembly[0].id) %> -->
+          <h5><%= assembly.name %></h5>
+        <!--  <% appkey = assembly.name + ".megam.io" %>
+          <%= link_to appkey, onedews_path(:appkey => assembly.id), :data => {:remote => true} %>
+          <%= link_to appkey, oneaddons_path(:appkey => assembly.id) %>
+          <%= link_to appkey, oneapps_path(:appkey => assembly.id) %> -->
           <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 col-xl-12">
             <ul class="list-inline app_icon_bottom">
-                  <%  assembly[0].components.each do |one_component| %>
+                  <%  assembly.components.each do |one_component| %>
                   <% one_component.each do |c| %>
                   <li>
                     <%= image_tag "logos/"+ one_component.tosca_type.downcase+".png", :alt => "" %>
@@ -80,11 +77,9 @@
       <div class="app_footer">
         <!-- <div class="circle_red"></div> -->
         <i class="circle_green"></i>
-        <span><strong><%= assembly[0].status %></strong></span>
-        <% if asm.inputs[:id].length > 1 %>
-        <% url = "http://#{Rails.configuration.designer_host}:#{Rails.configuration.designer_port}/?email=#{current_user.email}&api_key=#{current_user.api_key}&callbackURL=https://www.megam.co/varai&assembliesID=#{asm.id}" %>
+        <span><strong><%= assembly.status %></strong></span>
+        <% url = "http://#{Rails.configuration.designer_host}:#{Rails.configuration.designer_port}/?email=#{current_user.email}&api_key=#{current_user.api_key}&callbackURL=https://www.megam.co/varai&assembliesID=#{assembly.id}" %>
         <a href="<%= url %>" target="_blank" ><i class="c_icon-window pull-right" style="color:blue"></i></a>
-        <% end %>
         <i class="c_icon-star pull-right"></i>
       </div>
     </div>
@@ -138,7 +133,6 @@
     </div>
   </div>
 </div>
-<% end %>
 <% end %>
 <% end %>
 </div>

--- a/app/views/cockpits/_mycockpit.html.erb
+++ b/app/views/cockpits/_mycockpit.html.erb
@@ -36,11 +36,11 @@
 			</div>
 		</div>
 	</div>
-	
+
 	<div class="margin_30 pad_t25">
-		<%= render :partial => "cockpits/flyasm", :locals => {:catname => Assemblies::DEW.capitalize,    :assemblies_grouped => @assemblies_grouped} %>
-		<%= render :partial => "cockpits/flyasm", :locals => {:catname => Assemblies::APP.capitalize,    :assemblies_grouped => @assemblies_grouped} %>
-		<%= render :partial => "cockpits/flyasm", :locals => {:catname => Assemblies::SERVICE.capitalize,:assemblies_grouped => @assemblies_grouped} %>
+		<%= render :partial => "cockpits/flyasm", :locals => {:catname => Assemblies::DEW.capitalize,    :assemblies_grouped => @assemblies_grouped[Assemblies::DEW]} %>
+		<%= render :partial => "cockpits/flyasm", :locals => {:catname => Assemblies::APP.capitalize,    :assemblies_grouped => @assemblies_grouped[Assemblies::APP]} %>
+		<%= render :partial => "cockpits/flyasm", :locals => {:catname => Assemblies::SERVICE.capitalize,:assemblies_grouped => @assemblies_grouped[Assemblies::SERVICE]} %>
 	</div>
 </div>
 <% end %>

--- a/app/views/marketplaces/_dew.html.erb
+++ b/app/views/marketplaces/_dew.html.erb
@@ -128,7 +128,7 @@
 		<div class="row">
 			<div class="col-xs-12">
 				<div class="form-group">
-					<%= submit_tag "Create Dew", :class => "btn btn-success col-xs-12" %>
+					<%= submit_tag "Create Dew", :class => "btn btn-success col-xs-12", :data => {:remote => true} %>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
@thomasalrin  Thomas please test it and keep it moving to support complex scenario.  The image isn't hooked up to the assembly widget, start, stop button doesn't work yet.

![Megam cockpit](https://cloud.githubusercontent.com/assets/1402479/7522227/759f9e14-f511-11e4-8a22-0ebfc78ac1fa.png)

@thomasalrin @rajthilakmca @morpheyesh  We now have a Hash of assembly collection by cattypes. 
The `cattypes` are 

``` ruby
  CATTYPES            =  [APP, ADDON, DEW, ANALYTICS, SERVICE]
```

When an assembly is got from gateway, we look at its `tosca_type` which can be something like `tosca.dew.ubuntu` and we match the CATTYPES with the `tosca_type` and create a hash of that.

The `flyasm` view just uses the map of its own CATTYPE and displays them.
