### PR TITLE
When the healthcheck for gw fails, then show a message 

### DIFF
--- a/app/controllers/marketplaces_controller.rb
+++ b/app/controllers/marketplaces_controller.rb
@@ -65,7 +65,7 @@ class MarketplacesController < NilavuController
       Assembly.new.update(params)
       Components.new.update(params)
     end if params.key?(:bind_type)
-    toast_success(cockpits_path, "Launching <b>#{params['assemblyname']}.#{params['domain']}</b>. submitted, in progress.")
+    toast_success(cockpits_path, "Your #{params['cattype'].downcase} <b>#{params['name']}</b> is firing up")
   end
 
   ##

--- a/app/controllers/nilavu_controller.rb
+++ b/app/controllers/nilavu_controller.rb
@@ -40,16 +40,14 @@ class NilavuController < ApplicationController
     end
   end
 
-  #this works but has other issues like a stored session loops etc.
   def require_up
     hc = Nilavu::HealthCheck.new.tap do |h|
       h.check
     end
-
-    hok = hc.ok?
-    fail ConnectFailure, "Api server <b>@#{Ind.api}<b> is down.</br>✓ Fix: `start megamgateway` (or) contact your administrator." unless hok
-    hok
-    true
+    unless hc.ok?
+      flash[:alert] = "Is the api server - <b>#{Ind.api}</b> running ? chat (or) email <a href='support.megam.io'>support@megam.io</a> us."
+      fail
+    end
   end
 
   def stick_keys(_tmp = {}, _permitted_tmp = {})

--- a/app/controllers/phones_controller.rb
+++ b/app/controllers/phones_controller.rb
@@ -2,8 +2,8 @@ class PhonesController < ApplicationController
   def new
     pin_send = Nilavu::OTP::Infobip.new.send_pin("#{params['mobile_number']}")
     if pin_send == "Message sending failed"
-	flash[:error] = 'Sorry! OTP-PIN sending Failed!'
-	render js: "window.location = '#{params['redirect']}'" 
+	flash[:error] = 'Sorry! OTP-PIN sending failed!'
+	render js: "window.location = '#{params['redirect']}'"
     else
       session[:otp_pin_id] = pin_send
       session[:mobile_number] = "#{params['mobile_number']}"
@@ -15,7 +15,7 @@ class PhonesController < ApplicationController
 	@path = "#{params['redirect']}"
     unless pin_verify
 	flash[:error] = 'Sorry! Your pin is wrong!'
-	render js: "window.location = '#{@path}'" 
+	render js: "window.location = '#{@path}'"
     end
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,12 +24,11 @@
     <head>
       <base href="#">
       <%= favicon_link_tag 'megam_vertice_fav.png' %>
-      <title>Megam
-        <%= yield(:title) %></title>
+      <title>Vertice <%= yield(:title) %></title>
       <%= stylesheet_link_tag "application", :media => "all" %>
       <%= analytics_init if Rails.env.production? %>
       <%= javascript_include_tag "application" %>
-      <meta content="Megam cloud platform powers virtual office, backup analytics in one click." name="description=">
+      <meta content="Megam vertice - one stop shop for cloud." name="description=">
       <meta charset="utf-8"/>
       <meta content="IE=edge" http-equiv="X-UA-Compatible">
       <meta content="width=device-width, initial-scale=1.0" name="viewport"/>

--- a/lib/nilavu/error.rb
+++ b/lib/nilavu/error.rb
@@ -49,6 +49,8 @@ module Nilavu
   class MegamGWError < Nilavu::Error; end
   class CephError < Nilavu::Error; end
   class RiakError < Nilavu::Error; end
+  class VerticeHealthCheckError < Nilavu::Error; end
+
   class ResourceError < Nilavu::Error; end
 
   # An error class for when I don't know what happened.  Automatically


### PR DESCRIPTION
All the issues are for when "gw or riak, rabbitmq" is down.
We have fixed the case where just the `gw` is down. Rest are not relevant.
#761
#659  (We only show a growl msg when gateway is down)
#551
