### PR TITLE
Footer whitelabeling is tested and complete.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -36,7 +36,6 @@ class ApplicationController < ActionController::Base
   around_action :catch_exceptions
 
 
-
   # Some exceptions
   class RenderEmpty < StandardError; end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -56,21 +56,21 @@ module ApplicationHelper
   end
 
   def render_customized_header_or_not
-    unless customization_disabled?
+    if !customization_disabled?  && SiteCustomization.custom_header.present?
       return SiteCustomization.custom_header
     end
     render partial: 'layouts/header'
   end
 
   def render_customized_footer_or_not
-    unless customization_disabled?
+    if !customization_disabled? && SiteCustomization.custom_footer.present?
       return SiteCustomization.custom_footer
     end
     render partial: 'layouts/footer'
   end
 
   def self.all_customtags
-     Dir.glob("site/*.html.erb")
+    Dir.glob(File.join(ENV['MEGAM_HOME'], 'site/*.html.erb'))
   end
 
   def self.customtag_for_site(name)
@@ -78,12 +78,11 @@ module ApplicationHelper
     # Don't evaluate plugins in test
     return "" if Rails.env.test?
 
-    matcher = Regexp.new("/site/.*\#{name}.html\.erb$")
-    erbs = all_customtags.select {|c| c =~ matcher }
+    erbs = all_customtags.select {|c| c.include? name }
     return "" if erbs.blank?
 
     result = ""
-    erbs.each {|erb| result << render(file: erb) }
+    erbs.each {|erb| result << ERB.new(File.read(erb)).result }
     result.html_safe
   end
 

--- a/app/models/site_customization.rb
+++ b/app/models/site_customization.rb
@@ -11,10 +11,8 @@ class SiteCustomization
 
 
     def process_html(html)
-      Rails.cache.fetch("sitecustomization_#{html}", expires_in: 1.day) do
-        doc = Nokogiri::HTML.fragment(html)
-        doc.to_s
-      end
+      doc = Nokogiri::HTML.fragment(html)
+      doc.to_s
     end
 
 
@@ -28,7 +26,7 @@ class SiteCustomization
   end
 
   SiteCustomization.html_fields.each do |html_attr|
-    if erb = ApplicationHelper.customtag_for_site("{html_attr}")
+    if erb = ApplicationHelper.customtag_for_site("#{html_attr}")
       self.send("#{html_attr}=", erb)
     end
   end
@@ -39,38 +37,16 @@ class SiteCustomization
     end
   end
 
-  def self.enabled_key
-    ENABLED_KEY.dup
-  end
-
-  def self.field_for_target(target=nil)
-    target ||= :desktop
-
-    case target.to_sym
-    when :mobile then :mobile_stylesheet
-    when :desktop then :stylesheet
-    when :embedded then :embedded_css
-    end
-  end
-
-  def self.baked_for_target(target=nil)
-    "#{field_for_target(target)}_baked".to_sym
-  end
-
 
   %i{header top footer head_tag body_tag}.each do |name|
-    define_singleton_method("custom_#{name}") do |preview_style=nil, target=:desktop|
-      preview_style ||= ENABLED_KEY
-      lookup_field(preview_style, target, name)
+    define_singleton_method("custom_#{name}") do |target=:desktop|
+      lookup_field(target, name)
     end
   end
 
-  def self.lookup_field(key, target, field)
-    return if key.blank?
+  def self.lookup_field(target, field)
+    lookup = self.send("#{field}")
 
-    cache_key = key + target.to_s + field.to_s;
-
-    lookup = Rails.cache[cache_key]
     return lookup.html_safe if lookup
   end
 end

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -56,7 +56,7 @@
                   <% if session[:auth] %>
                     <%= password_field_tag 'password', nil, :required => true, :class=> 'form-control', placeholder: t('signup.email'), :value => @password %>
                   <% else %>
-                    <%= password_field_tag 'password', nil, :required => true, :class=> 'form-control', placeholder: t('signup.email') %>
+                    <%= password_field_tag 'password', nil, :required => true, :class=> 'form-control', placeholder: t('signup.password') %>
                   <% end %>
                 </div>
               </div>

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe CockpitsController do
+describe ApplicationController do
 
   describe 'set_locale' do
     it 'sets the one the user prefers' do


### PR DESCRIPTION
To use this create a file in $MEGAM_HOME/site/footer.html.erb. It has to be named as `footer.html.erb`

Sample tested with our `footer.html.erb` "sans" internationalization, as every site will know its language. And i couldn't load `i18n` in the `footer` file.

``` erb
<!--
** Copyright [2013-2016] [Megam Systems]
**
** Licensed under the Apache License, Version 2.0 (the "License");
** you may not use this file except in compliance with the License.
** You may obtain a copy of the License at
**
** http://www.apache.org/licenses/LICENSE-2.0
**
** Unless required by applicable law or agreed to in writing, software
** distributed under the License is distributed on an "AS IS" BASIS,
** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
** See the License for the specific language governing permissions and
** limitations under the License.
-->
<div class="container">
    <div class="row">
        <div class="col-sm-12 footer-menu">
            <ul class="list-inline text-center">
                <li>
                    <a href="https://www.megam.io" target="_blank">Megam.io</a>
                </li>
                <li>
                    <a href="http://docs.megam.io" target="_blank">Documentation</a>
                </li>
                <li>
                    <a href="http://devcenter.megam.io" target="_blank">Dev center</a>
                </li>
                <li>
                    <a href="http://support.megam.io" target="_blank">Support</a>
                </li>
            </ul>
        </div>
        <div class="col-sm-12">
            <p class="text-center">
                copyright: © 2013-2016 megam. All rights reserved.
            </p>
        </div>
    </div>
</div>
```
