### PR TITLE
Setting up predeploy and the dash gets refreshed upon a launch.

### DIFF
--- a/app/assets/javascripts/nilavu/controllers/discovery/topics.js.es6
+++ b/app/assets/javascripts/nilavu/controllers/discovery/topics.js.es6
@@ -59,6 +59,7 @@ const controllerOpts = {
       return false;
     },
 
+    // Awesome, don't know where this is called but used after we launch.
     refresh() {
       const filter = this.get('model.filter');
 
@@ -76,7 +77,6 @@ const controllerOpts = {
         TopicList.hideUniformCategory(list, this.get('category'));
 
         this.setProperties({ model: list });
-        this.resetSelected();
 
         if (this.topicTrackingState) {
           this.topicTrackingState.sync(list, filter);

--- a/app/assets/javascripts/nilavu/controllers/edit-category.js.es6
+++ b/app/assets/javascripts/nilavu/controllers/edit-category.js.es6
@@ -150,6 +150,7 @@ export default Ember.Controller.extend(ModalFunctionality, {
                   self.set('saving', false);
                   self.send('closeModal');
 
+                NilavuURL.routeTo('/');
               //NilavuURL.redirectTo("/c/" + Nilavu.Category.slugFor(model));
               }).catch(function(error) {
                 alert("error is ="+ error);

--- a/app/assets/javascripts/nilavu/routes/topic-predeploy.js.es6
+++ b/app/assets/javascripts/nilavu/routes/topic-predeploy.js.es6
@@ -1,0 +1,19 @@
+import { loadTopicView } from 'discourse/models/topic';
+
+export default Discourse.Route.extend({
+  model(params) {
+    const topic = this.store.createRecord("topic", { id: params.id });
+    return loadTopicView(topic).then(() => topic);
+  },
+
+  afterModel(topic) {
+    topic.set("details.notificationReasonText", null);
+  },
+
+  actions: {
+    didTransition() {
+      this.controllerFor("application").set("showFooter", true);
+      return true;
+    }
+  }
+});


### PR DESCRIPTION
Figured a way to setup predeploy. 
- `we'll use loadTopicView`
- hookup http://codepen.io/ugross/pen/zAitb in the UI
- Use the notification code committed last night for periodic checking/update.
- The VNC bar at the top grabbed from `vm management`
