### PR TITLE
The userVisible flag is turned off. Modal fix for smallTitle

### DIFF
--- a/app/assets/javascripts/nilavu/controllers/discovery/topics.js.es6
+++ b/app/assets/javascripts/nilavu/controllers/discovery/topics.js.es6
@@ -34,7 +34,7 @@ const controllerOpts = {
 
       const promise =  this.openComposer(this.controllerFor("discovery/topics")).then(function(result) {
         self.set('loading', false);
-        showModal('editCategory', {model: result});
+        showModal('editCategory', {model: result, smallTitle: false, titleCentered: true});
       }).catch(function(e) {
           self.set('loading', false);
       });

--- a/app/assets/javascripts/nilavu/controllers/modal.js.es6
+++ b/app/assets/javascripts/nilavu/controllers/modal.js.es6
@@ -1,1 +1,9 @@
-export default Ember.Controller.extend();
+export default Ember.Controller.extend({
+
+    headCentered: function() {
+        if (this.get('titleCentered')) {
+            return 'text-center';
+        }
+    }.property('titleCentered')
+
+});

--- a/app/assets/javascripts/nilavu/lib/show-modal.js.es6
+++ b/app/assets/javascripts/nilavu/lib/show-modal.js.es6
@@ -21,6 +21,15 @@ export default function(name, opts) {
     if (controller) { renderArgs.controller = name; }
 
     route.render('modal/' + templateName, renderArgs);
+
+    if (opts.smallTitle) {
+        modalController.set('smallTitle', opts.smallTitle);
+    }
+
+    if (opts.titleCentered) {
+        modalController.set('titleCentered', opts.titleCentered);
+    }
+
     if (opts.title) {
       modalController.set('title', I18n.t(opts.title));
     }

--- a/app/assets/javascripts/nilavu/templates/modal/modal.hbs
+++ b/app/assets/javascripts/nilavu/templates/modal/modal.hbs
@@ -5,7 +5,11 @@
             <div class="row">
                <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 col-xl-12">
                  <a class="close pull-right" {{action "closeModal"}}>{{fa-icon "remove"}}</a>
-                  <h1 class="text-center modal-title">{{title}}</h1>
+                   {{#if smallTitle}}
+                    <h4 class="modal-title {{headCentered}}">{{title}}</h4>
+                    {{else}}
+                    <h1 class="modal-title {{headCentered}}">{{title}}</h1>
+                  {{/if}}
                 </div>
             </div>
           </div>

--- a/app/assets/javascripts/nilavu/widgets/header.js.es6
+++ b/app/assets/javascripts/nilavu/widgets/header.js.es6
@@ -155,7 +155,7 @@ export default createWidget('header', {
         return {
             marketplacesVisible: true,
             storagesVisible: true,
-            userVisible: true,
+            userVisible: false,
             contextEnabled: false
         };
     },
@@ -183,7 +183,7 @@ export default createWidget('header', {
     },
 
     closeAll() {
-        this.state.userVisible = true;
+        this.state.userVisible = false;
         this.state.marketplacesVisible = true;
         this.state.storagesVisible = true;
     },


### PR DESCRIPTION
### For the Modal,
### In any modal, you have two more flags.
- smallTitle: `for stuff like forgot-password`  [true/false]
- titleCentered: [true/false] self explanatory :)

If you wish to change the size of the modal. 

Then in your `onShow function` which gets called during the `init` automatically in the modal.
- add a method `changeSize` and set the modal class with what you want `this.set('controllers.modal.modalClass', 'edit-category-modal full');

Eg: `edit-category - controller (the new launcher) Yeah a dull name`

```
onShow() {
        this.changeSize();
    },

   //here we change the size based on if its virtualmachine or an app
    changeSize: function() {
        if (this.get('selectionSelected') && (!this.get('isVirtualMachine'))) {
            this.set('controllers.modal.modalClass', 'edit-category-modal full');
        } else if (this.get('selectionSelected')) {
            this.set('controllers.modal.modalClass', 'edit-category-modal small');
        } else {
          this.set('controllers.modal.modalClass', 'edit-category-modal full');
        }
    }.observes('isVirtualMachine', 'generalSelected', 'selectionSelected', 'summarySelected'),


```
