### PR TITLE
Show marketplaces - Virtualmachine is fixed. Rest will follow today.

### DIFF
--- a/app/assets/javascripts/nilavu/components/search-result-virtualmachine.js.es6
+++ b/app/assets/javascripts/nilavu/components/search-result-virtualmachine.js.es6
@@ -21,6 +21,7 @@ export default Em.Component.extend({
   actions: {
 
     edit() {
+      this.notificationMessages.success(this.get('resultType.name').toLowerCase() + ' selected.');
       this.set('category.versionoption', this.get('resultType.name').toLowerCase());
       this.set('category.versiondetail', this.get('resultType'));
       this.set('versionOption', true);

--- a/app/assets/javascripts/nilavu/controllers/marketplaces.js.es6
+++ b/app/assets/javascripts/nilavu/controllers/marketplaces.js.es6
@@ -1,0 +1,38 @@
+import BufferedContent from 'nilavu/mixins/buffered-content';
+import { spinnerHTML } from 'nilavu/helpers/loading-spinner';
+//import Marketplaces from 'nilavu/models/marketplaces';
+import { popupAjaxError } from 'nilavu/lib/ajax-error';
+import computed from 'ember-addons/ember-computed-decorators';
+
+export default Ember.Controller.extend(BufferedContent, {
+    needs: ['application'],
+    //rerenderTriggers: ['isUploading'], rerenderTriggers for search filter.
+
+    title: 'Marketplaces',
+
+    _initPanels: function() {
+    }.on('init'),
+
+    //check the freewheeling site setting flag for true or false
+    minifiedVersion: function() {
+        return false;
+    }.property('selectedTab'),
+
+
+    actions: {
+
+        showMarketplaceItem() {
+            alert('showMakitem');
+        },
+
+
+        save() {
+        },
+
+    },
+
+    hasError: Ember.computed.or('model.notFoundHtml', 'model.message'),
+
+    noErrorYet: Ember.computed.not('hasError')
+
+});

--- a/app/assets/javascripts/nilavu/controllers/user-private-messages.js.es6
+++ b/app/assets/javascripts/nilavu/controllers/user-private-messages.js.es6
@@ -1,5 +1,5 @@
 import computed from 'ember-addons/ember-computed-decorators';
-import Topic from 'discourse/models/topic';
+import Topic from 'nilavu/models/topic';
 
 export default Ember.Controller.extend({
   needs: ["application", "user-topics-list", "user"],

--- a/app/assets/javascripts/nilavu/routes/app-route-map.js.es6
+++ b/app/assets/javascripts/nilavu/routes/app-route-map.js.es6
@@ -1,6 +1,7 @@
 export default function() {
 
-    //Fake route
+    //Fake route, we will remove it once we are done.
+
     this.route('dummy');
     // Error page
     this.route('exception', { path: '/exception' });
@@ -43,14 +44,15 @@ export default function() {
       this.route('show', { path: '/' });
     });
 
-    this.route('marketplaces', { path: '/marketplaces' });
-
-    //this.route('storages', { path: '/storages' });
+    this.resource('marketplaces', {path:'/marketplaces'}, function() {
+        this.route('show', { path: '/' });
+    });
 
     // User routes
     this.resource('users');
     this.resource('user', { path: '/user/:email' }, function() {
         this.route('show',{ path: '/' });
+
         this.resource('userActivity', { path: '/activity' }, function() {
             this.route('topics');
             this.route('replies');
@@ -92,5 +94,4 @@ export default function() {
         this.route('show', { path: '/' });
         this.route('files',{ path: '/files' });
     });
-
 }

--- a/app/assets/javascripts/nilavu/routes/marketplaces-show.js.es6
+++ b/app/assets/javascripts/nilavu/routes/marketplaces-show.js.es6
@@ -1,0 +1,17 @@
+import BufferedContent from 'nilavu/mixins/buffered-content';
+
+export default Nilavu.Route.extend({
+
+    renderTemplate() {
+        this.render('navigation/default', {
+            outlet: 'navigation-bar'
+        });
+
+        this.render('marketplaces/show', {
+            controller: 'marketplaces',
+            outlet: 'list-container'
+        });
+    }
+
+
+});

--- a/app/assets/javascripts/nilavu/templates/marketplaces.hbs
+++ b/app/assets/javascripts/nilavu/templates/marketplaces.hbs
@@ -1,0 +1,14 @@
+<div class="container-fluid main-cover vm">
+  <div class="row">
+    <div class="col-xs-12 col-sm-3 col-md-2 col-xl-1 c_bg_white">
+      <div class="row">
+        <div class="page-sidebar navbar-collapse collapse">
+          {{outlet "navigation-bar"}}
+        </div>
+      </div>
+    </div>
+    <div id="list-container">
+      {{outlet "list-container"}}
+    </div>
+  </div>
+</div>

--- a/app/assets/javascripts/nilavu/templates/marketplaces/show.hbs
+++ b/app/assets/javascripts/nilavu/templates/marketplaces/show.hbs
@@ -1,0 +1,28 @@
+<div class="rt-box col-xs-12 col-sm-9 col-md-10 c_bg_white c_height_5">
+    {{raw "topic-list-header" currentUser=currentUser title=title nameEnabled=nameEnabled name=name}}
+    <div class="bottom-divider"></div>
+    <div class="cat_title">
+        <h4>Virtual Machines<small>
+                <i>Get your own compute power</i>
+            </small>
+        </h4>
+        <div class="col-xs-12">
+            <div class="row app_box ">
+                <div class="col-xs-12 col-sm-6 col-md-4 col-lg-3 col-xl-3 app_cover ">
+                    <div class="app_inner brad-3">
+                        <a data-toggle="modal" href="#app-1">
+                            <div class="stpack">
+                                <a href="/marketplaces/ubuntu">
+                                    <img  src="../images/brands/saas/ubuntu.png">
+                                </a>
+                            </div>
+                        </a>
+                        <div class="" style="display:none">
+                            Ubuntu
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/app/assets/javascripts/nilavu/widgets/header.js.es6
+++ b/app/assets/javascripts/nilavu/widgets/header.js.es6
@@ -117,7 +117,6 @@ createWidget('header-icons', {
             align: 'pull-left',
             icon: 'c_icon-window-lg',
             iconId: 'marketplace-button',
-            active: attrs.marketplacesVisible,
             resource: 'marketplaces'
         });
 
@@ -127,14 +126,11 @@ createWidget('header-icons', {
             align: 'pull-left',
             icon: 'c_icon-storages-lg',
             iconId: 'toggle-storages-menu',
-            active: attrs.storageVisible,
             resource: 'storages'
         });
 
-
-
         const icons = [marketplaces, storages];
-
+        
         if (this.currentUser) {
             icons.push(this.attach('user-dropdown', {
                 active: attrs.userVisible,


### PR DESCRIPTION
The base structure is in.

@megamsys/megam-dev  Guys - in `header.js.es6`, the **active: marketplacesVisible** flag, if set to `true` automatically toggles the dropdown.

In case of `Storages, Marketplaces` these are just links, hence we don't need them.

Here is the UI, I just have to pull the data based on `category` and show them.

![screenshot from 2016-06-26 10-52-45](https://cloud.githubusercontent.com/assets/1402479/16360690/a7b20834-3b8c-11e6-9e4a-687649629314.png)
